### PR TITLE
Webpack building

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ Check `config/themes.json.sample` to get samples
 - `modules` - list of modules witch you want to map inside your theme
 - `ignore` - array of ignore patterns
 
+## Webpack building
+The `webpack` task will compile both local and vendor based webpack bundles (the specific module needs to be specified in `/dev/tools/frontools/config/themes.json` for the module to be compiled).
+
+```json
+    ...
+    "modules": {
+        "Ampersand_Local": "app/code/Ampersand/Local",
+        "Ampersand_Vendor": "vendor/ampersand/magento2-vendor"
+    }
+```
+
+The bundle also needs to have a entry file in the format `*.babel.js` for the compilation to work.
+
 ## Optional configurations for 3rd party plugins
 * Create [browserSync](https://www.browsersync.io/) configuration
 * Create [eslint](https://github.com/adametry/gulp-eslint) configuration

--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ Check `config/themes.json.sample` to get samples
   * `--theme name` - Process single theme.
   * `--disableLinting` - Disable SASS and CSS linting.
   * `--disableMaps` - Enable inline source maps generation.
+* `webpack` - Run webpack and compiles bundles if any.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Check `config/themes.json.sample` to get samples
 * `babel` - Run [Babel](https://babeljs.io/), a compiler for writing next generation JavaScript.
   * `--theme name` - Process single theme.
   * `--prod` - Production output - minifies and uglyfy code.
+* `build` - Run inheritance, styles task and webpack building.
+  * `--prod` - Production output - minifies styles and add `.min` sufix.
 * `browser-sync` - Run [browserSync](https://www.browsersync.io/).
 * `clean` - Removes `/pub/static` directory content.
 * `csslint` - Run [stylelint](https://github.com/stylelint/stylelint) based tests.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The `webpack` task will compile both local and vendor based webpack bundles (the
     }
 ```
 
+See [this PR](https://github.com/AmpersandHQ/m2-ee/pull/3/files#diff-585600f4e9c5485604262df0af1adf9a) for a full example.
+
 The bundle also needs to have a entry file in the format `*.babel.js` for the compilation to work.
 
 ## Optional configurations for 3rd party plugins

--- a/helper/webpack-build.js
+++ b/helper/webpack-build.js
@@ -24,21 +24,13 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
     return path;
   }
 
-    var debug = require('gulp-debug');
     var webpack = require('webpack-stream');
-    var tap = require('gulp-tap');
-    var util = require('gulp-util');
-    var map = require('map');
     var vinylPaths = require('vinyl-paths');
 
     const dest = [];
     theme.locale.forEach(locale => {
       dest.push(config.projectPath + theme.dest + '/' + locale);
     });
-
-    var mylog = function(file, cb) {
-      cb(null, file);
-    };
 
     return gulp.src(
       file || srcBase + '/**/*.babel.js',

--- a/helper/webpack-build.js
+++ b/helper/webpack-build.js
@@ -43,7 +43,7 @@ module.exports = function (gulp, plugins, config, name, file) { // eslint-disabl
 
             return new Promise(function (resolve, reject) {
                 webpack(require(webpackfile))
-                    .pipe(gulp.dest(moduleDir + 'view/front/js/dist/'))
+                    .pipe(gulp.dest(moduleDir + 'view/frontend/web/js/dist/'))
                     .on('end', resolve)
             });
         }))

--- a/helper/webpack-build.js
+++ b/helper/webpack-build.js
@@ -1,0 +1,73 @@
+'use strict';
+module.exports = function(gulp, plugins, config, name, file) { // eslint-disable-line func-names
+  const theme       = config.themes[name],
+        srcBase     = config.projectPath + 'var/view_preprocessed/frontools' + theme.dest.replace('pub/static', ''),
+        stylesDir   = theme.stylesDir ? theme.stylesDir : 'styles',
+        disableMaps = plugins.util.env.disableMaps || false,
+        production  = plugins.util.env.prod || false,
+        babelConfig = {
+          presets: require('babel-preset-env')
+        };
+
+  function adjustDestinationDirectory(file) {
+    file.dirname = file.dirname.replace('web/', '');
+    return file;
+  }
+
+  function getModuleDir(file) {
+    var path = file.replace(/view\/frontend\/web\/js\/(.*)\.babel\.js/, '');
+    return path;
+  }
+
+  function getJsDir(file) {
+    var path = file.path.replace(/'(.*).babel.js'/, '');
+    return path;
+  }
+
+    var debug = require('gulp-debug');
+    var webpack = require('webpack-stream');
+    var tap = require('gulp-tap');
+    var util = require('gulp-util');
+    var map = require('map');
+    var vinylPaths = require('vinyl-paths');
+
+    const dest = [];
+    theme.locale.forEach(locale => {
+      dest.push(config.projectPath + theme.dest + '/' + locale);
+    });
+
+    var mylog = function(file, cb) {
+      cb(null, file);
+    };
+
+    return gulp.src(
+      file || srcBase + '/**/*.babel.js',
+      { base: srcBase }
+    )
+    .pipe(
+        plugins.if(
+            !plugins.util.env.ci,
+            plugins.plumber({
+                errorHandler: plugins.notify.onError('Error: <%= error.message %>')
+            })
+        )
+    )
+    .pipe(vinylPaths(function(path) {
+        var moduleDir = getModuleDir(path);
+        var webpackfile = moduleDir + 'webpack.config.js';
+
+        return new Promise(function(resolve, reject) {
+            webpack(require(webpackfile))
+                .pipe(gulp.dest(moduleDir + 'view/frontend/web/js/dist/'))
+                .on('end', resolve)
+        });
+    }))
+    .pipe(plugins.rename(adjustDestinationDirectory))
+    .pipe(plugins.multiDest(dest))
+    .pipe(plugins.logger({
+        display   : 'name',
+        beforeEach: 'Theme: ' + name + ' ',
+        afterEach : ' Compiled!'
+    }))
+    .pipe(plugins.browserSync.stream());
+};

--- a/helper/webpack-build.js
+++ b/helper/webpack-build.js
@@ -15,20 +15,18 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
   }
 
   function getModuleDir(file) {
-    var path = file.replace(/view\/frontend\/web\/js\/(.*)\.babel\.js/, '');
-    return path;
+      return file.replace(/view\/frontend\/web\/js\/(.*)\.babel\.js/, '');
   }
 
   function getJsDir(file) {
-    var path = file.path.replace(/'(.*).babel.js'/, '');
-    return path;
+      return file.path.replace(/'(.*).babel.js'/, '');
   }
 
     var webpack = require('webpack-stream');
     var vinylPaths = require('vinyl-paths');
 
     const dest = [];
-    theme.locale.forEach(locale => {
+    theme.locale.forEach(function(locale) {
       dest.push(config.projectPath + theme.dest + '/' + locale);
     });
 
@@ -50,7 +48,7 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
 
         return new Promise(function(resolve, reject) {
             webpack(require(webpackfile))
-                .pipe(gulp.dest(moduleDir + 'view/frontend/web/js/dist/'))
+                .pipe(gulp.dest(moduleDir + 'view/front/js/dist/'))
                 .on('end', resolve)
         });
     }))

--- a/helper/webpack-build.js
+++ b/helper/webpack-build.js
@@ -1,63 +1,58 @@
 'use strict';
-module.exports = function(gulp, plugins, config, name, file) { // eslint-disable-line func-names
-  const theme       = config.themes[name],
-        srcBase     = config.projectPath + 'var/view_preprocessed/frontools' + theme.dest.replace('pub/static', ''),
-        stylesDir   = theme.stylesDir ? theme.stylesDir : 'styles',
+module.exports = function (gulp, plugins, config, name, file) { // eslint-disable-line func-names
+    const theme = config.themes[name],
+        srcBase = config.projectPath + 'var/view_preprocessed/frontools' + theme.dest.replace('pub/static', ''),
+        stylesDir = theme.stylesDir ? theme.stylesDir : 'styles',
         disableMaps = plugins.util.env.disableMaps || false,
-        production  = plugins.util.env.prod || false,
-        babelConfig = {
-          presets: require('babel-preset-env')
-        };
+        production = plugins.util.env.prod || false,
+        babelConfig = {presets: require('babel-preset-env')};
 
-  function adjustDestinationDirectory(file) {
-    file.dirname = file.dirname.replace('web/', '');
-    return file;
-  }
+    function adjustDestinationDirectory(file) {
+        file.dirname = file.dirname.replace('web/', '');
+        return file;
+    }
 
-  function getModuleDir(file) {
-      return file.replace(/view\/frontend\/web\/js\/(.*)\.babel\.js/, '');
-  }
+    function getModuleDir(file) {
+        return file.replace(/view\/frontend\/web\/js\/(.*)\.babel\.js/, '');
+    }
 
-  function getJsDir(file) {
-      return file.path.replace(/'(.*).babel.js'/, '');
-  }
+    function getJsDir(file) {
+        return file.path.replace(/'(.*).babel.js'/, '');
+    }
 
     var webpack = require('webpack-stream');
     var vinylPaths = require('vinyl-paths');
 
     const dest = [];
-    theme.locale.forEach(function(locale) {
-      dest.push(config.projectPath + theme.dest + '/' + locale);
+    theme.locale.forEach(function (locale) {
+        dest.push(config.projectPath + theme.dest + '/' + locale);
     });
 
-    return gulp.src(
-      file || srcBase + '/**/*.babel.js',
-      { base: srcBase }
-    )
-    .pipe(
-        plugins.if(
-            !plugins.util.env.ci,
-            plugins.plumber({
-                errorHandler: plugins.notify.onError('Error: <%= error.message %>')
-            })
+    return gulp.src(file || srcBase + '/**/*.babel.js', {base: srcBase})
+        .pipe(
+            plugins.if(
+                !plugins.util.env.ci,
+                plugins.plumber({
+                    errorHandler: plugins.notify.onError('Error: <%= error.message %>')
+                })
+            )
         )
-    )
-    .pipe(vinylPaths(function(path) {
-        var moduleDir = getModuleDir(path);
-        var webpackfile = moduleDir + 'webpack.config.js';
+        .pipe(vinylPaths(function (path) {
+            var moduleDir = getModuleDir(path);
+            var webpackfile = moduleDir + 'webpack.config.js';
 
-        return new Promise(function(resolve, reject) {
-            webpack(require(webpackfile))
-                .pipe(gulp.dest(moduleDir + 'view/front/js/dist/'))
-                .on('end', resolve)
-        });
-    }))
-    .pipe(plugins.rename(adjustDestinationDirectory))
-    .pipe(plugins.multiDest(dest))
-    .pipe(plugins.logger({
-        display   : 'name',
-        beforeEach: 'Theme: ' + name + ' ',
-        afterEach : ' Compiled!'
-    }))
-    .pipe(plugins.browserSync.stream());
+            return new Promise(function (resolve, reject) {
+                webpack(require(webpackfile))
+                    .pipe(gulp.dest(moduleDir + 'view/front/js/dist/'))
+                    .on('end', resolve)
+            });
+        }))
+        .pipe(plugins.rename(adjustDestinationDirectory))
+        .pipe(plugins.multiDest(dest))
+        .pipe(plugins.logger({
+            display: 'name',
+            beforeEach: 'Theme: ' + name + ' ',
+            afterEach: ' Compiled!'
+        }))
+        .pipe(plugins.browserSync.stream());
 };

--- a/helper/webpack-dist.js
+++ b/helper/webpack-dist.js
@@ -21,7 +21,6 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
 
     return gulp.src(
       [
-        file || srcBase + '/**/*.js', 
         file || srcBase + '/**/*.min.js', 
         '!' + srcBase + '/**/node_modules/**/*.js'
       ],

--- a/helper/webpack-dist.js
+++ b/helper/webpack-dist.js
@@ -1,0 +1,45 @@
+'use strict';
+module.exports = function(gulp, plugins, config, name, file) { // eslint-disable-line func-names
+  const theme       = config.themes[name],
+        srcBase     = config.projectPath + 'var/view_preprocessed/frontools' + theme.dest.replace('pub/static', ''),
+        stylesDir   = theme.stylesDir ? theme.stylesDir : 'styles',
+        disableMaps = plugins.util.env.disableMaps || false,
+        production  = plugins.util.env.prod || false,
+        babelConfig = {
+          presets: require('babel-preset-env')
+        };
+
+  function adjustDestinationDirectory(file) {
+    file.dirname = file.dirname.replace('web/', '');
+    return file;
+  }
+
+    const dest = [];
+    theme.locale.forEach(locale => {
+      dest.push(config.projectPath + theme.dest + '/' + locale);
+    });
+
+    return gulp.src(
+      [
+        file || srcBase + '/**/*.js', 
+        file || srcBase + '/**/*.min.js', 
+        '!' + srcBase + '/**/node_modules/**/*.js'
+      ],
+      { base: srcBase }
+    )
+      .pipe(
+        plugins.if(
+          !plugins.util.env.ci,
+          plugins.plumber({
+            errorHandler: plugins.notify.onError('Error: <%= error.message %>')
+          })
+        )
+      ).pipe(plugins.rename(adjustDestinationDirectory))
+        .pipe(plugins.multiDest(dest))
+        .pipe(plugins.logger({
+            display   : 'name',
+            beforeEach: 'Theme: ' + name + ' ',
+            afterEach : ' Compiled!'
+        }))
+        .pipe(plugins.browserSync.stream());
+};

--- a/helper/webpack-dist.js
+++ b/helper/webpack-dist.js
@@ -15,7 +15,7 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
   }
 
     const dest = [];
-    theme.locale.forEach(locale => {
+    theme.locale.forEach(function(locale) {
       dest.push(config.projectPath + theme.dest + '/' + locale);
     });
 

--- a/helper/webpack-dist.js
+++ b/helper/webpack-dist.js
@@ -9,10 +9,10 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
           presets: require('babel-preset-env')
         };
 
-  function adjustDestinationDirectory(file) {
-    file.dirname = file.dirname.replace('web/', '');
-    return file;
-  }
+    function adjustDestinationDirectory(file) {
+        file.dirname = file.dirname.replace('view/frontend/web/', '');
+        return file;
+    }
 
     const dest = [];
     theme.locale.forEach(function(locale) {
@@ -21,7 +21,6 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
 
     return gulp.src(
       [
-        file || srcBase + '/**/*.js', 
         file || srcBase + '/**/*.min.js', 
         '!' + srcBase + '/**/node_modules/**/*.js'
       ],
@@ -36,10 +35,5 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
         )
       ).pipe(plugins.rename(adjustDestinationDirectory))
         .pipe(plugins.multiDest(dest))
-        .pipe(plugins.logger({
-            display   : 'name',
-            beforeEach: 'Theme: ' + name + ' ',
-            afterEach : ' Compiled!'
-        }))
         .pipe(plugins.browserSync.stream());
 };

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "stylelint": "~7.9.0",
     "stylelint-config-standard": "~16.0.0",
     "vinyl-paths": "^2.1.0",
+    "webpack": "^2.5.1",
     "webpack-stream": "^3.2.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "postcss-reporter": "~3.0.0",
     "run-sequence": "~1.2.2",
     "stylelint": "~7.9.0",
-    "stylelint-config-standard": "~16.0.0"
+    "stylelint-config-standard": "~16.0.0",
+    "vinyl-paths": "^2.1.0",
+    "webpack-stream": "^3.2.0"
   },
   "scripts": {
     "test": "./node_modules/eslint/bin/eslint.js *.js helper/*.js task/*.js"

--- a/task/build.js
+++ b/task/build.js
@@ -1,0 +1,13 @@
+'use strict';
+module.exports = function() { // eslint-disable-line func-names
+  // Global variables
+  const gulp    = this.gulp,
+        plugins = this.opts.plugins,
+        config  = this.opts.configs,
+        themes  = plugins.getThemes(),
+        streams = plugins.mergeStream();
+
+  plugins.runSequence('styles', 'webpack-build', 'webpack-dist');
+
+  return streams;
+};

--- a/task/webpack-build.js
+++ b/task/webpack-build.js
@@ -1,0 +1,17 @@
+'use strict';
+module.exports = function() { // eslint-disable-line func-names
+  // Global variables
+  const gulp    = this.gulp,
+        plugins = this.opts.plugins,
+        config  = this.opts.configs,
+        themes  = plugins.getThemes(),
+        streams = plugins.mergeStream(),
+        webpack = this.webpack;
+
+  // Loop through themes to compile scss or less depending on your config.json
+  themes.forEach(name => {
+    streams.add(require('../helper/webpack-build')(gulp, plugins, config, name));
+  });
+
+  return streams;
+};

--- a/task/webpack-dist.js
+++ b/task/webpack-dist.js
@@ -1,0 +1,17 @@
+'use strict';
+module.exports = function() { // eslint-disable-line func-names
+  // Global variables
+  const gulp    = this.gulp,
+        plugins = this.opts.plugins,
+        config  = this.opts.configs,
+        themes  = plugins.getThemes(),
+        streams = plugins.mergeStream(),
+        webpack = this.webpack;
+
+  // Loop through themes to compile scss or less depending on your config.json
+  themes.forEach(name => {
+    streams.add(require('../helper/webpack-dist')(gulp, plugins, config, name));
+  });
+
+  return streams;
+};

--- a/task/webpack.js
+++ b/task/webpack.js
@@ -1,0 +1,13 @@
+'use strict';
+module.exports = function() { // eslint-disable-line func-names
+  // Global variables
+  const gulp    = this.gulp,
+        plugins = this.opts.plugins,
+        config  = this.opts.configs,
+        themes  = plugins.getThemes(),
+        streams = plugins.mergeStream();
+
+  plugins.runSequence('inheritance', 'webpack', 'webpackdist');
+
+  return streams;
+};

--- a/task/webpack.js
+++ b/task/webpack.js
@@ -7,7 +7,7 @@ module.exports = function() { // eslint-disable-line func-names
         themes  = plugins.getThemes(),
         streams = plugins.mergeStream();
 
-  plugins.runSequence('inheritance', 'webpack', 'webpackdist');
+  plugins.runSequence('inheritance', 'webpack-build', 'webpack-dist');
 
   return streams;
 };


### PR DESCRIPTION
This PR adds a gulp task to run webpack building. It will compile both local and vendor based webpack bundles (the specific module needs to be specified in `/dev/tools/frontools/config/themes.json` for the module to be compiled).

For webpack three new tasks have been added: 

* `webpack-build` - this looks for `*.babel.js` files and a related webpack config file. If found it runs webpack using the configuration and creates a bundle in `var/view_preprocessed`. 
* `webpack-dist` - this moves the compiled bundled from `var/view_preprocessed` into `pub/static`
* `webpack` - this runs the `inheritance` task, `webpack-build` and `webpack-dist` in sequence. 

There is also a new `build` task to be used when initially setting up a project or on pull of new files. This runs both the `styles` task and the above `webpack` task.

