### PR TITLE
update webpack version, change entry file name

### DIFF
--- a/helper/webpack-build.js
+++ b/helper/webpack-build.js
@@ -13,14 +13,15 @@ module.exports = function (gulp, plugins, config, name, file) { // eslint-disabl
     }
 
     function getModuleDir(file) {
-        return file.replace(/view\/frontend\/web\/js\/(.*)\.babel\.js/, '');
+        return file.replace(/view\/frontend\/web\/js\/(.*)\.entry\.js/, '');
     }
 
     function getJsDir(file) {
-        return file.path.replace(/'(.*).babel.js'/, '');
+        return file.path.replace(/'(.*).entry.js'/, '');
     }
 
-    var webpack = require('webpack-stream');
+    var webpackStream = require('webpack-stream');
+    var webpack = require('webpack');
     var vinylPaths = require('vinyl-paths');
 
     const dest = [];
@@ -28,7 +29,7 @@ module.exports = function (gulp, plugins, config, name, file) { // eslint-disabl
         dest.push(config.projectPath + theme.dest + '/' + locale);
     });
 
-    return gulp.src(file || srcBase + '/**/*.babel.js', {base: srcBase})
+    return gulp.src(file || srcBase + '/**/*.entry.js', {base: srcBase})
         .pipe(
             plugins.if(
                 !plugins.util.env.ci,
@@ -42,7 +43,7 @@ module.exports = function (gulp, plugins, config, name, file) { // eslint-disabl
             var webpackfile = moduleDir + 'webpack.config.js';
 
             return new Promise(function (resolve, reject) {
-                webpack(require(webpackfile))
+                webpackStream(require(webpackfile), webpack)
                     .pipe(gulp.dest(moduleDir + 'view/frontend/web/js/dist/'))
                     .on('end', resolve)
             });

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "stylelint": "~7.9.0",
     "stylelint-config-standard": "~16.0.0",
     "vinyl-paths": "^2.1.0",
-    "webpack": "^2.5.1",
+    "webpack": "^3.2.0",
     "webpack-stream": "^3.2.0"
   },
   "scripts": {


### PR DESCRIPTION
Now using webpack `^3.2.0` and explicitly use webpack version in webpack-stream.

Entry file for webpack modules is now expected to be `*.entry.js`