### PR TITLE
Add scenario filter flag to backstop task

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The bundle also needs to have a entry file in the format `*.babel.js` for the co
   * `--reference` - Create reference screenshots
   * `--test` - Take new screenshots and compare against reference ones, launch the results report in the browser
   * `--approve` - If there are new changes that are OK, update the reference screenshots with the test ones
+  * `--filter=foo` - Add this flag after `--reference` or `--test` with a regex matching scenarios you want to test (e.g. foo)
 * `babel` - Run [Babel](https://babeljs.io/), a compiler for writing next generation JavaScript.
   * `--theme name` - Process single theme.
   * `--prod` - Production output - minifies and uglyfy code.

--- a/helper/backstop.js
+++ b/helper/backstop.js
@@ -13,13 +13,20 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
     if (plugins.util.env.genConfig) {
         console.log("Don't run this, run gulp setup instead [TODO]");
     } else if (plugins.util.env.reference) {
+        if (plugins.util.env.filter) {
+            backstopOptions.filter = plugins.util.env.filter;
+        }
         return plugins.backstopjs('reference', backstopOptions);
     } else if (plugins.util.env.test) {
+        if (plugins.util.env.filter) {
+            backstopOptions.filter = plugins.util.env.filter;
+        }
         return plugins.backstopjs('test', backstopOptions);
     } else if (plugins.util.env.approve) {
         return plugins.backstopjs('approve', backstopOptions);
     } else {
         console.log("Error, run with a flag to specify the required task: --reference, --test or --approve");
+        console.log("Or run the --filter flag alongside the --reference or --test flag");
     }
   }
 };

--- a/task/backstop.js
+++ b/task/backstop.js
@@ -5,7 +5,7 @@ module.exports = function() { // eslint-disable-line func-names
         plugins = this.opts.plugins,
         config  = this.opts.configs,
         themes  = plugins.getThemes();
-  console.log(plugins.util.env);
+
   themes.forEach(name => {
     plugins.util.log(
       plugins.util.colors.green('Runing BackstopJs on') + ' '


### PR DESCRIPTION
There is a lovely feature in Backstop that allows you to run only certain scenarios instead of every single one when you `--test` or `--reference`. I want to make use of it in Demon Tweeks to target areas of the Astrum styleguide which I think will make life easier. [https://github.com/garris/BackstopJS#filtering-tests-and-references-by-scenario](https://github.com/garris/BackstopJS#filtering-tests-and-references-by-scenario)

It allows you to add the `--filter=xxx` flag alongside the `--test` or `--reference` with a string that matches the scenario you want to test.

This means that I can select e.g. the `lists` scenario in my new backstop config in https://github.com/AmpersandHQ/demon-tweeks/pull/417

I've tagged everyone in because I don't know who needs to see it or who cares and I also don't know whether this is welcome at the moment with magepack stuff 😖 