### PR TITLE
Run backstop once against styleguide

### DIFF
--- a/helper/backstop.js
+++ b/helper/backstop.js
@@ -1,10 +1,8 @@
 'use strict';
-module.exports = function(gulp, plugins, config, name, file) { // eslint-disable-line func-names
+module.exports = function(gulp, plugins, config, file) { // eslint-disable-line func-names
 
   return () => {
-    const theme          = config.themes[name],
-          srcBase        = config.projectPath + 'var/view_preprocessed/frontools' + theme.dest.replace('pub/static', ''),
-          backstopConfig = require('../helper/config-loader')('backstop.json', plugins, config),
+    const backstopConfig = require('../helper/config-loader')('backstop.json', plugins, config),
           backstopConfigFilePath = config.projectPath + 'dev/tools/frontools/config/backstop.json',
           backstopOptions = {
                "backstopConfigFilePath": backstopConfigFilePath

--- a/task/backstop.js
+++ b/task/backstop.js
@@ -8,7 +8,7 @@ module.exports = function() { // eslint-disable-line func-names
 
   // themes.forEach(name => {
     plugins.util.log(
-      plugins.util.colors.green('Runing BackstopJs')
+      plugins.util.colors.green('Running BackstopJs')
     );
     require('../helper/backstop')(gulp, plugins, config)();
   // });

--- a/task/backstop.js
+++ b/task/backstop.js
@@ -6,12 +6,10 @@ module.exports = function() { // eslint-disable-line func-names
         config  = this.opts.configs,
         themes  = plugins.getThemes();
 
-  themes.forEach(name => {
+  // themes.forEach(name => {
     plugins.util.log(
-      plugins.util.colors.green('Runing BackstopJs on') + ' '
-      + plugins.util.colors.blue(name) + ' '
-      + plugins.util.colors.green('theme...')
+      plugins.util.colors.green('Runing BackstopJs')
     );
-    require('../helper/backstop')(gulp, plugins, config, name)();
-  });
+    require('../helper/backstop')(gulp, plugins, config)();
+  // });
 };

--- a/task/backstop.js
+++ b/task/backstop.js
@@ -6,10 +6,9 @@ module.exports = function() { // eslint-disable-line func-names
         config  = this.opts.configs,
         themes  = plugins.getThemes();
 
-  // themes.forEach(name => {
-    plugins.util.log(
-      plugins.util.colors.green('Running BackstopJs')
-    );
-    require('../helper/backstop')(gulp, plugins, config)();
-  // });
+  plugins.util.log(
+    plugins.util.colors.green('Running BackstopJs')
+  );
+
+  require('../helper/backstop')(gulp, plugins, config)();
 };

--- a/task/csslint.js
+++ b/task/csslint.js
@@ -9,7 +9,7 @@ module.exports = function() { // eslint-disable-line func-names
 
   themes.forEach(name => {
     plugins.util.log(
-      plugins.util.colors.green('Runing CSS Lint on') + ' '
+      plugins.util.colors.green('Running CSS Lint on') + ' '
       + plugins.util.colors.blue(name) + ' '
       + plugins.util.colors.green('theme...')
     );

--- a/task/sasslint.js
+++ b/task/sasslint.js
@@ -9,7 +9,7 @@ module.exports = function() { // eslint-disable-line func-names
 
   themes.forEach(name => {
     plugins.util.log(
-      plugins.util.colors.green('Runing SASS Lint on') + ' '
+      plugins.util.colors.green('Running SASS Lint on') + ' '
       + plugins.util.colors.blue(name) + ' '
       + plugins.util.colors.green('theme...')
     );


### PR DESCRIPTION
Backstop was being run once per theme - which with our current setup is incorrect because

* there is only one styleguide
* if there were multiple styleguides then we should calculate that differently as stylguides live in their own directories and not `app/design`.