### PR TITLE
Fix semver error with backstop

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "autoprefixer": "~6.7.7",
     "babel-preset-env": "~1.2.1",
-    "backstopjs": "^2.6.11",
+    "backstopjs": "~2.6.11",
     "browser-sync": "~2.18.8",
     "cssnano": "~3.10.0",
     "eslint-config-idiomatic": "~3.1.0",


### PR DESCRIPTION
There has been a major 3.0.0 release of Backstop. Even though we had
`"backstopjs": "^2.6.11"` in the package.json we were still getting the
new changes, specifically
https://github.com/garris/BackstopJS/blob/0535303326e658e69d78f6405aac390b620ff222/capture/genBitmaps.js#L203
which changed vp.name to vp.label which broke everything.

I've changed the package.json to `"backstopjs": "~2.6.11",` in the
meantime and this fixes the errors.