### PR TITLE
Revert "Merge pull request #24 from AmpersandHQ/backstop/version"

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "autoprefixer": "~6.7.7",
     "babel-preset-env": "~1.2.1",
-    "backstopjs": "~2.6.11",
+    "backstopjs": "^3",
     "browser-sync": "~2.18.8",
     "cssnano": "~3.10.0",
     "eslint-config-idiomatic": "~3.1.0",


### PR DESCRIPTION
> This reverts commit 3d1b8bd7a9ba507ea7858c74b67fcd56fa715ec7, reversing
changes made to ab29971875ef027993be390eb2774726946df002.

Reverts unnecessary work in https://github.com/AmpersandHQ/magento2-frontools/pull/24 by running `git revert -m 1 <merge-commit-sha>`

Backstop is now at version 3. Works fine in my project with `"engine": "phantomjs"` now. ¯\_(ツ)_/¯

When testing with `chrome` or `chromy` as the engine, it changed the viewport of all the existing screenshots, so in DT I'm keeping the engine with `phantomjs` for now, but something to bear in mind for new projects.