### PR TITLE
Feature/MSR-758, Add NPM bridge to automatically install node modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
         }
     },
     "require": {
-        "magento/framework": "*"
+        "magento/framework": "*",
+        "eloquent/composer-npm-bridge": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.5"
     },
-    "type": "magento2-component",
     "license": "MIT",
     "type": "magento2-component"
 }


### PR DESCRIPTION
https://ampersand.atlassian.net/browse/MSR-758

This PR adds the https://github.com/eloquent/composer-npm-bridge package which automatically installs this modules NPM dependencies when installed through composer. This mitigates the need for manually installing the dependencies when building an M2 project.

This functionality has also been added to the base theme https://github.com/AmpersandHQ/magento2-base-theme/blob/master/composer.json#L22