### PR TITLE
[WIP] Fix ESLint

### DIFF
--- a/gulpfile.esm.js
+++ b/gulpfile.esm.js
@@ -24,6 +24,7 @@ import { setupBackstop } from './tasks/ampersand/setup-backstop'
 import { setupTemplates } from './tasks/ampersand/setup-templates'
 import backstopTask from './tasks/ampersand/backstop'
 import imageminTask from './tasks/ampersand/imagemin'
+import { eslint as eslintTask } from './tasks/ampersand/eslint'
 
 export const babel = series(inheritanceTask, babelTask)
 export const clean = cleanTask
@@ -46,6 +47,7 @@ export const backstop = backstopTask
 export const imagemin = imageminTask
 export const webpack = series(inheritanceTask, webpackBuild, webpackDist)
 export const build = series(styles, babel, webpackBuildTask, webpackDistTask)
+export const eslint = eslintTask
 // NOTE: This changes the default setup task that comes with Frontools to use theirs and
 // ours. Done like this as we already tell people to run `gulp setup` to get the tools folder
 // symlinked (etc.), so rather than breaking established habit, let's just keep the

--- a/helpers/ampersand/eslint.js
+++ b/helpers/ampersand/eslint.js
@@ -1,0 +1,34 @@
+import path from 'path';
+import { src } from 'gulp';
+import globby from 'globby';
+import plumber from 'gulp-plumber';
+import gulpIf from 'gulp-if';
+import notify from 'gulp-notify';
+import logger from 'gulp-logger';
+import eslint from 'gulp-eslint';
+
+import { env, themes, tempPath } from '../config';
+import configLoader from '../config-loader';
+
+export default (name, file) => {
+    const theme = themes[name]
+    const srcBase = path.join(tempPath, theme.dest)
+    const eslintConfig = configLoader('eslint.json')
+    const files = globby.sync(srcBase + '/**/*.js')
+
+    return src(file ? file : files.length ? files : '.')
+        .pipe(gulpIf(
+            !env.ci,
+            plumber({
+                errorHandler: notify.onError('Error: <%= error.message %>')
+            })
+        ))
+        .pipe(eslint(eslintConfig))
+        // .pipe(sassLint.format())
+        // .pipe(gulpIf(env.ci, sassLint.failOnError()))
+        .pipe(logger({
+            display   : 'name',
+            beforeEach: 'Theme: ' + name + ' ' + 'File: ',
+            afterEach : ' - ESLint finished.'
+        }))
+};

--- a/helpers/ampersand/eslint.js
+++ b/helpers/ampersand/eslint.js
@@ -11,10 +11,10 @@ import { env, themes, tempPath } from '../config';
 import configLoader from '../config-loader';
 
 export default (name, file) => {
-    const theme = themes[name]
-    const srcBase = path.join(tempPath, theme.dest)
-    const eslintConfig = configLoader('eslint.json')
-    const files = globby.sync(srcBase + '/**/*.js')
+    const theme = themes[name];
+    const srcBase = path.join(tempPath, theme.src);
+    const eslintConfig = configLoader('eslintrc.yml');
+    const files = globby.sync(srcBase + '/**/*.js');
 
     return src(file ? file : files.length ? files : '.')
         .pipe(gulpIf(
@@ -24,8 +24,8 @@ export default (name, file) => {
             })
         ))
         .pipe(eslint(eslintConfig))
-        // .pipe(sassLint.format())
-        // .pipe(gulpIf(env.ci, sassLint.failOnError()))
+        .pipe(eslint.format())
+        .pipe(gulpIf(env.ci, eslint.failOnError()))
         .pipe(logger({
             display   : 'name',
             beforeEach: 'Theme: ' + name + ' ' + 'File: ',

--- a/tasks/ampersand/eslint.js
+++ b/tasks/ampersand/eslint.js
@@ -1,0 +1,17 @@
+import mergeStream from 'merge-stream';
+import log from 'fancy-log';
+import colors from 'ansi-colors';
+
+import helper from '../../helpers/ampersand/eslint';
+import themes from '../../helpers/get-themes';
+
+export const eslint = () => {
+    const streams = mergeStream();
+
+    themes().forEach(name => {
+        log(`${colors.green('Runing ESLint on')} ${colors.blue(name)} ${colors.green('theme...')}`);
+        streams.add(helper(name))
+    });
+
+    return streams;
+};


### PR DESCRIPTION
After a bit of investigation, it seems that the eslint that comes with the original Frontools is still using the 'old' version (looking for plugins in the project etc) and hasn't been formatted to work with the updated codebase. This fixes it at least for us so we can at least lint things. 

### To do
- [x] Fix eslint to work
- [ ] Update to import/use our linters (both ESlint and (S)CSSlint)
- [ ] See if we can stop it looking in the `var/view_preprocessed` folder (maybe?)

### Questions
- [ ] Should we add linting to Travis?
- [ ] If we're moving towards PWA for future projects, do we even need to do this here? 
- [ ] Should we lint the `requirejs-config.js` files? 